### PR TITLE
Fix installed_OS_is_rocky8.xml to check Rocky8

### DIFF
--- a/ComplianceAsCode/content_for_supporting_rocky8/README.md
+++ b/ComplianceAsCode/content_for_supporting_rocky8/README.md
@@ -1,1 +1,25 @@
-# These are files for supporting Rocky8 for ComplianceAsCode content.
+# Rocky8 files and tools
+These are files for supporting Rocky8 for ComplianceAsCode content. 'Files' directory contain files for modifying ComplianceAsCode [content](https://github.com/ComplianceAsCode/content). 'Tools' directory contain script for modifying ComplianceAsCode content to support Rocky8.
+
+## Rocky8 product information.
+Just for now, we use following Name/Values as Rocky8 product informtation(content/rocky8/product.yml)
+
+1. fingerprints vaules. For Redhat, we can check it on [https://access.redhat.com/security/team/key](https://access.redhat.com/security/team/key)
+```pkg_release: "PKG_RELASE"
+ pkg_version: "PKG_VERSION"
+ aux_pkg_release: "AUX_PKG_RELEASE"
+ aux_pkg_version: "AUX_PKG_VERSION"
+ 
+ release_key_fingerprint: "RELEASE_KEY_FINGERPRINT"
+ auxiliary_key_fingerprint: "AUXILIARY_KEY_FINGERPRINT"
+```
+
+2. OVAL Feed URL. If we will use completely same as RHEL8 OVAL, we might not be need to change it.
+```
+oval_feed_url: "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml"
+```
+
+3. CPE. CPE name is in /etc/os-release and /etc/system-release-cpe.
+```
+name: "cpe:/o:rocky:rocky_linux:8"
+```

--- a/ComplianceAsCode/content_for_supporting_rocky8/files/installed_OS_is_rocky8.xml
+++ b/ComplianceAsCode/content_for_supporting_rocky8/files/installed_OS_is_rocky8.xml
@@ -11,49 +11,37 @@
       <description>The operating system installed on the system is
       Rocky Linux 8</description>
     </metadata>
-    <criteria>
-      <criterion comment="Installed operating system is part of the unix family"
-      test_ref="test_rocky8_unix_family" />
-      <criteria operator="OR">
-        <criterion comment="Rocky Linux 8 is installed" test_ref="test_rocky8" />
-        <criteria operator="AND" comment="Red Hat Enterprise Virtualization Host is installed">
-          <criterion comment="Red Hat Virtualization Host (RHVH)" test_ref="test_rhvh4_version" />
-          <criterion comment="Red Hat Enterprise Virtualization Host is based on Rocky Linux 8" test_ref="test_rhevh_rocky8_version" />
-        </criteria>
-      </criteria>
+    <criteria operator="AND">
+      <extend_definition comment="Installed OS is part of the Unix family"
+      definition_ref="installed_OS_is_part_of_Unix_family" />
+      <criterion comment="OS is Rocky Linux" test_ref="test_rocky8_name" />
+      <criterion comment="OS version is 8" test_ref="test_rocky8_version" />
     </criteria>
   </definition>
 
-  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_rocky8_unix_family" version="1">
-    <ind:object object_ref="obj_rocky8_unix_family" />
-    <ind:state state_ref="state_rocky8_unix_family" />
-  </ind:family_test>
-  <ind:family_state id="state_rocky8_unix_family" version="1">
-    <ind:family>unix</ind:family>
-  </ind:family_state>
-  <ind:family_object id="obj_rocky8_unix_family" version="1" />
-
-  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release is version 8" id="test_rocky8" version="1">
-    <linux:object object_ref="obj_rocky8" />
-    <linux:state state_ref="state_rocky8" />
-  </linux:rpminfo_test>
-  <linux:rpminfo_state id="state_rocky8" version="1">
-    <linux:version operation="pattern match">^8.*$</linux:version>
-  </linux:rpminfo_state>
-  <linux:rpminfo_object id="obj_rocky8" version="1">
-    <linux:name>redhat-release</linux:name>
-  </linux:rpminfo_object>
-
-  <ind:textfilecontent54_test check="all" comment="RHEVH base Rocky Linux is version 8" id="test_rhevh_rocky8_version" version="1">
-    <ind:object object_ref="obj_rhevh_rocky8_version" />
-    <ind:state state_ref="state_rhevh_rocky8_version" />
+  <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="Check os-release ID" id="test_rocky8_name" version="1">
+    <ind:object object_ref="obj_name_rocky8" />
+    <ind:state state_ref="state_name_rocky8" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="obj_rhevh_rocky8_version" version="1">
-    <ind:filepath>/etc/redhat-release</ind:filepath>
-    <ind:pattern operation="pattern match">^Rocky Linux release (\d)\.\d+$</ind:pattern>
-    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  <ind:textfilecontent54_object id="obj_name_rocky8" version="1" comment="Check os-release ID">
+    <ind:filepath>/etc/os-release</ind:filepath>
+    <ind:pattern operation="pattern match">^ID=&quot;(\w+)&quot;$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-  <ind:textfilecontent54_state id="state_rhevh_rocky8_version" version="1">
-    <ind:subexpression operation="pattern match">8</ind:subexpression>
+  <ind:textfilecontent54_state id="state_name_rocky8" version="1">
+    <ind:subexpression>rocky</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_test check="all" comment="Check os-release VERSION_ID" id="test_rocky8_version" version="1">
+    <ind:object object_ref="obj_version_rocky8" />
+    <ind:state state_ref="state_version_rocky8" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_version_rocky8" version="1" comment="Check os-release VERSION_ID">
+    <ind:filepath>/etc/os-release</ind:filepath>
+    <ind:pattern operation="pattern match">^VERSION_ID=&quot;(\d)&quot;$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_version_rocky8" version="1">
+    <ind:subexpression>8</ind:subexpression>
   </ind:textfilecontent54_state>
 </def-group>


### PR DESCRIPTION
I fixed installed_OS_is_rocky8.xml (issue09) for supporting Rocky8. I'm testing contents from this ComplianceAsCode source with modified CentOS8(modified /etc/os-release, /etc/system-release-cpe. 